### PR TITLE
Rewrite utils.getFileContent to be async

### DIFF
--- a/bin/compare-locales.js
+++ b/bin/compare-locales.js
@@ -17,9 +17,9 @@ function compareLocales(appPath, lang) {
     app.getLangpacks().then(function() {
       var lp1 = app.langpacks[app.defaultLocale];
       var lp2 = app.langpacks[lang];
-      var lpDiff = compareLangpacks(lp1, lp2);
-      var txt = serializeLangpackDiffToText(lpDiff);
-      console.log(txt);
+      compareLangpacks(lp1, lp2).then(
+        serializeLangpackDiffToText).then(
+          console.log);
     });
   });
 }
@@ -33,9 +33,9 @@ function compareLocales2(appPath, langPath, lang) {
 
     app.getLangpacks().then(function() {
       var lp1 = app.langpacks[app.defaultLocale];
-      var lpDiff = compareLangpacks(lp1, lp);
-      var txt = serializeLangpackDiffToText(lpDiff);
-      console.log(txt);
+      compareLangpacks(lp1, lp).then(
+        serializeLangpackDiffToText).then(
+          console.log);
     });
   });
 }

--- a/lib/format/utils.js
+++ b/lib/format/utils.js
@@ -16,8 +16,7 @@ exports.parseSource = function(type, source) {
 
 exports.getResource = function(resPath) {
   var type = resPath.substring(resPath.lastIndexOf('.') + 1);
+  var parse = parsers[type].parse.bind(parsers[type]);
 
-  var resSource = utils.getFileContent(resPath);
-  var resStruct = parsers[type].parse(resSource);
-  return resStruct;
+  return utils.getFileContent(resPath).then(parse);
 };

--- a/lib/mozilla/apps/gaia.js
+++ b/lib/mozilla/apps/gaia.js
@@ -113,11 +113,8 @@ function isNotTestFile(path) {
 }
 
 function traverseCollection(fn, col) {
-  if (!col.forEach) {
-    return fn(col);
-  }
-
-  col.forEach(traverseCollection.bind(null, fn));
+  return !col.forEach ?
+    fn(col) : col.forEach(traverseCollection.bind(null, fn));
 }
 
 function flattenResources(resLists) {
@@ -135,16 +132,15 @@ function getResourcesFromHTMLFiles(appPath) {
 }
 
 function getResourcesFromHTMLFile(htmlPath) {
-  var htmlContent = utils.getFileContent(htmlPath);
-  return utils.getDocument(htmlContent).then(function(doc) {
-    var results = [];
-    var links = doc.head.querySelectorAll('link[rel="localization"]');
-    for (var i = 0; i < links.length; i++) {
-      var link = links[i];
-      results.push(link.getAttribute('href'));
-    }
-    return results;
-  });
+  return utils.getFileContent(htmlPath)
+    .then(utils.getDocument)
+    .then(function(doc) {
+      return Array.prototype.map.call(
+        doc.head.querySelectorAll('link[rel="localization"]'),
+        function(link) {
+          return link.getAttribute('href');
+        });
+    });
 }
 
 exports.GaiaApp = GaiaApp;

--- a/lib/mozilla/diff/compare.js
+++ b/lib/mozilla/diff/compare.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Promise = require('promise');
 var deepEqual = require('deep-equal');
 
 var LangpackDiff = require('./core.js').LangpackDiff;
@@ -10,39 +11,46 @@ var utils = require('../utils.js');
 var formatUtils = require('../../format/utils.js');
 
 function compareLangpacks(lp1, lp2) {
-  var diff = new LangpackDiff(lp2.code);
+  function createLangpackDiff(parsedDiffs) {
+    return new LangpackDiff(lp2.code, parsedDiffs);
+  }
 
-  var listDiff = utils.listDiff(Object.keys(lp1.resources),
-                                Object.keys(lp2.resources));
+  var listDiff = utils.listDiff(
+    Object.keys(lp1.resources),
+    Object.keys(lp2.resources));
 
-  listDiff.forEach(function(elem) {
-    var resID = elem[0];
+  return Promise.all(
+    listDiff.map(compareElement.bind(null, lp1, lp2))).then(
+      createLangpackDiff);
+}
 
-    switch(elem[1]) {
-      case 'list1':
-        diff.entries.push(['missing', resID]);
-        break;
-      case 'list2':
-        diff.entries.push(['obsolete', resID]);
-        break;
-      case 'both':
-        var resDiff =
-          compareResources(lp1.resources[resID], lp2.resources[resID]);
-        diff.entries.push(['present', resID, resDiff]);
-        break;
-    }
-  });
-  return diff;
+function compareElement(lp1, lp2, elem) {
+  var resID = elem[0];
+
+  switch(elem[1]) {
+    case 'list1':
+      return ['missing', resID];
+    case 'list2':
+      return ['obsolete', resID];
+    case 'both':
+      return compareResources(
+        lp1.resources[resID], lp2.resources[resID]).then(function(resDiff) {
+          return ['present', resID, resDiff];
+        });
+  }
 }
 
 function compareResources(res1, res2) {
+  return Promise.all(
+    [res1.path, res2.path].map(formatUtils.getResource)).then(
+      Function.prototype.apply.bind(compareStructs, null));
+}
+
+function compareStructs(struct1, struct2) {
   var resDiff = new ResourceDiff();
-
-  var res1Struct = formatUtils.getResource(res1.path);
-  var res2Struct = formatUtils.getResource(res2.path);
-
-  var listDiff = utils.listDiff(Object.keys(res1Struct),
-                                Object.keys(res2Struct));
+  var listDiff = utils.listDiff(
+    Object.keys(struct1),
+    Object.keys(struct2));
 
   listDiff.forEach(function(elem) {
     var entryId = elem[0];
@@ -55,7 +63,7 @@ function compareResources(res1, res2) {
         break;
       case 'both':
         var entryDiff =
-          compareEntries(res1Struct[entryId], res2Struct[entryId], entryId);
+          compareEntries(struct1[entryId], struct2[entryId], entryId);
         resDiff.entries.push(['present', entryId, entryDiff]);
         break;
     }

--- a/lib/mozilla/diff/core.js
+++ b/lib/mozilla/diff/core.js
@@ -1,8 +1,8 @@
 'use strict';
 
-function LangpackDiff(code) {
+function LangpackDiff(code, entries) {
   this.code = code;
-  this.entries = [];
+  this.entries = entries;
 }
 
 function ResourceDiff() {

--- a/lib/mozilla/utils.js
+++ b/lib/mozilla/utils.js
@@ -25,7 +25,15 @@ exports.ls = function ls(dir, recursive, pattern) {
 };
 
 exports.getFileContent = function(path, type) {
-  return fs.readFileSync(path, {encoding: type || 'utf-8'});
+  return new Promise(function(resolve, reject) {
+    fs.readFile(path, {encoding: type || 'utf-8'}, function(err, data) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });
 };
 
 exports.splitPath = function(path) {
@@ -72,18 +80,13 @@ exports.listDiff = function(list1, list2) {
 
 exports.getDocument = function(content) {
   return new Promise(function (resolve, reject) {
-    jsdom.env(
-      content,
-      [],
-      function (errors, window) {
-        if (errors) {
-          reject(errors);
-        } else {
-          resolve(window.document);
-        }
-
+    jsdom.env(content, [], function(errors, window) {
+      if (errors) {
+        reject(errors);
+      } else {
+        resolve(window.document);
       }
-    );
+    });
   });
 };
 

--- a/tests/compare.js
+++ b/tests/compare.js
@@ -30,18 +30,20 @@ suite('Compare langpacks 2 args', function() {
   });
 
   test('compares two langpacks', function(done) {
-    var lpDiff = compareLangpacks(lp1, lp2);
-    var txt = serializeLangpackDiffToText(lpDiff);
     var outputPath = path.join(__dirname, 'fixtures', 'output.txt');
 
-    fs.readFile(outputPath, {encoding: 'utf8'}, function(err, data) {
-      if (err) {
-        throw err;
-      }
+    compareLangpacks(lp1, lp2).then(
+      serializeLangpackDiffToText).then(function(txt) {
+        fs.readFile(outputPath, {encoding: 'utf8'}, function(err, data) {
+          if (err) {
+            throw err;
+          }
 
-      assert.equal(txt, data.slice(0, -1));
-      done();
+          assert.equal(txt, data.slice(0, -1));
+          done();
+        });
     });
+
   });
 
 });


### PR DESCRIPTION
I'd like to rewrite all IO functions to be async.  In this pull request, I started with `utils.getFileContent`.  As a result, `compareLocales` is now async too and returns a promise.
